### PR TITLE
Move license info to top level LICENSE file for GitHub

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,3 @@
+# License
+
+Except as otherwise noted, the content of this repo is licensed under the [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/) ([local copy](LICENSES/CC-BY-4.0.txt)), and any code is licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html) ([local copy](LICENSES/APACHE-2.0.txt)).

--- a/README.md
+++ b/README.md
@@ -24,8 +24,3 @@ See [How to Get Involved](https://github.com/gitops-working-group/gitops-working
 ## Code of Conduct
 
 The OpenGitOps community follows the [CNCF Code of Conduct](https://github.com/open-gitops/.github/blob/main/CODE_OF_CONDUCT.md).
-
-## Licenses
-
-- Code: [Apache 2.0](LICENSES/APACHE-2.0.txt). [html](http://www.apache.org/licenses/LICENSE-2.0.html)
-- Non-code: [CC BY 4.0](LICENSES/CC-BY-4.0.txt). [html](https://creativecommons.org/licenses/by/4.0/legalcode)


### PR DESCRIPTION
For GitHub multiple license info, see:
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/licensing-a-repository

Works for https://github.com/licensee/licensee formatting.

Note this follows [cnf-wg](https://github.com/cncf/cnf-wg) as an example, because it seems fitting for this project (and added more details about CNCF project compliance here https://github.com/open-gitops/documents/issues/2).