### PR TITLE
docs(CI Ops): CIops -> CI Ops

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -32,7 +32,7 @@ These principles were derived from modern software operations but are rooted in 
 ### Principle 3 Notes
 
 - These differences could be due to the actual state drifting from the desired state, or the desired state changing intentionally.
-- The source of drift doesn't matter. Contrary to CIops, _any_ drift will trigger a reconciliation
+- The source of drift doesn't matter. Contrary to CI Ops, _any_ drift will trigger a reconciliation
 
 ### Principle 4 Notes
 


### PR DESCRIPTION
Spell this as CI Ops.  Reason: CIops reads like Clops, which caused me to look up what Clops (CLOPS) means.  After not finding the acronym CLOPS, I realized that I misread CIops as Clops.  By changing the spelling from CIops to CI Ops, this mitigates the risks of other people misreading too.

For example, do you read the following as CIops or Clops?
<img width="666" alt="Do you read ths as CIops or Clops?" src="https://user-images.githubusercontent.com/1329685/121631216-81843480-ca33-11eb-98a5-66eb9c7a75a4.png">

https://user-images.githubusercontent.com/1329685/121631216-81843480-ca33-11eb-98a5-66eb9c7a75a4.png
is a screenshot of
https://github.com/open-gitops/documents/blob/main/PRINCIPLES.md#principle-3-notes

I misread the above as Clops instead of CIops.