### PR TITLE
Simplify first sentence of each principle, for easy memorization

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -10,20 +10,20 @@ These principles were derived from modern software operations but are rooted in 
 
 ## Principles
 
-1. **The principle of declarative desired state**
+1. **Use declarative infrastructure**
 
     A system managed by GitOps must have its _Desired State_ expressed declaratively as data in a format writable and readable by both humans and machines.
 
-2. **The principle of immutable desired state versions**
+2. **Use immutable, versioned storage**
 
     _Desired State_ is stored in a way that supports versioning, immutability of versions, and retains a complete version history.
 
-3. **The principle of continuous state reconciliation**
+3. **Use continuous state reconciliation**
 
     Software agents continuously, and automatically, compare a system's _Actual State_ to its _Desired State_.
     If the actual and desired states differ for any reason, automated actions to reconcile them are initiated.
 
-4. **The principle of operations through declaration**
+4. **Use declaration as the sole way of operating a system**
 
     The only mechanism through which the system is intentionally operated on is through these principles.
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -10,7 +10,7 @@ These principles were derived from modern software operations but are rooted in 
 
 ## Principles
 
-1. **Use declarative infrastructure**
+1. **Define state declaratively**
 
     A system managed by GitOps must have its _Desired State_ expressed declaratively as data in a format writable and readable by both humans and machines.
 
@@ -18,7 +18,7 @@ These principles were derived from modern software operations but are rooted in 
 
     _Desired State_ is stored in a way that supports versioning, immutability of versions, and retains a complete version history.
 
-3. **Use continuous state reconciliation**
+3. **Reconcile state continiously**
 
     Software agents continuously, and automatically, compare a system's _Actual State_ to its _Desired State_.
     If the actual and desired states differ for any reason, automated actions to reconcile them are initiated.


### PR DESCRIPTION
Signed-off-by: Dan Garfield <dan@todaywasawesome.com>

The "Use" is repetitive but declarative. They can be taken as axioms this way instead of a descriptor of a longer principle beneath. I think the principle should be a short line and the additional text should clarify and expand the principle.