### PR TITLE
Address notes on the principles and remove the notes section

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -31,18 +31,18 @@ These principles were derived from modern software operations but are rooted in 
 
 - ### Break Glass
 
-    The temporary suspension of GitOps principles, most often pausing automated _Reconciliation_.
-    While these principles apply to "regular operations," it may sometimes be necessary to pause or sidestep them during an emergency such as incident management.
-    In these cases, other modes of operations should be considered (e.g. manual intervention), followed by any necessary updates to the desired state declarations, and finally resuming reconciliation of the manually changed system with the updated declarations again.
+    The temporary suspension of GitOps principles, often accomplished by pausing automated _Reconciliation_.
+    While these principles apply to typical operations, it may at times be necessary to temporarily pause reconciliation, for example during incident management activities.
+    In these cases, other modes of operations should be considered (e.g. manual intervention), followed by any necessary updates to the desired state declarations, and finally resuming reconciliation of the system with the updated declarations.
     Pragmatic exceptions to these guiding principles are expected from time to time during the journey toward a system being fully managed by GitOps.
 
 - ### Continuous
 
-    By "continuous" we adopt the industry standard term to mean _Reconciliation_ continues to happen, not that it must be instantaneous.
+    By "continuous" we adopt the industry standard to mean that _Reconciliation_ continues to happen, not that it must be instantaneous.
 
 - ### Declarative Description
 
-    Describing the desired state or behavior of a system without specifying how that state will be achieved, thereby separating between configuration (the desired state) and implementation (the commands, API calls, scripts etc.) that actually achieves the desired state described in the declarative description.
+    Describing the desired state or behavior of a system without specifying how that state will be achieved, thereby separating configuration (the desired state) from the implementation (commands, API calls, scripts etc.) that actually achieves the desired state described in the declarative description.
 
 - ### Desired State
 
@@ -50,11 +50,11 @@ These principles were derived from modern software operations but are rooted in 
 
 - ### Drift
 
-    When a system's _Actual State_ changes for any reason other than its versioned _Desired State_ declarations having changed, we say that the system has drifted from it's _Desired State_.
+    When a system's _Actual State_ changes for any reason other than its versioned _Desired State_ declarations having changed, we say that the system has drifted from its _Desired State_.
 
 - ### Reconciliation
 
-    The process of ensuring that the _Actual State_ of a sytem matches it's versioned _Desired State_ declarations.
+    The process of ensuring that the _Actual State_ of a sytem matches its versioned _Desired State_ declarations.
     Contrary to CIops, any divergence between the two will trigger reconciliation, regardless of where changes occured.
     Divergence could be due to the actual state unintentionally _Drifting_ from the desired state declarations, or a new desired state declaration version having been changed intentionally.
 
@@ -70,5 +70,5 @@ These principles were derived from modern software operations but are rooted in 
 
     A system for storing immutable versions of _Desired State_ declarations.
     This state store should provide access control and auditing on the changes to the Desired State.
-    Git is most often used as this State Store, but other systems may be used.
-    In all cases these must be properly configured, and special precautions must be taken, to comply with requirements set out in the GitOps Principles.
+    Git is the canonical example used as this State Store, and where GitOps derived its name, but but any other system that meets this criteria may be used.
+    In all cases these must be properly configured, and special precautions must be taken to comply with requirements set out in the GitOps Principles.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -37,11 +37,11 @@ These principles were derived from modern software operations but are rooted in 
 
 - ### Continuous
 
-    By "continuous" we adopt the industry standard term to mean reconciliation continues to happen, not that it must be instantaneous.
+    By "continuous" we adopt the industry standard term to mean _Reconciliation_ continues to happen, not that it must be instantaneous.
 
 - ### Declarative Description
 
-    Describing the desired state or behavior of a system without specifying how that state will be achieved, thereby separating between configuration - the desired state - and implementation - the commands, API calls, scripts ... that actually achieve the desired state described in the declarative description.
+    Describing the desired state or behavior of a system without specifying how that state will be achieved, thereby separating between configuration (the desired state) and implementation (the commands, API calls, scripts etc.) that actually achieves the desired state described in the declarative description.
 
 - ### Desired State
 
@@ -65,6 +65,6 @@ These principles were derived from modern software operations but are rooted in 
     One or more Administrators who are responsible for operating the runtime environments ie. installing, starting, stopping and updating software, code, configuration, etc.
     A set of policies controlling access and management of repositories, deployments, runtimes.
 
-- #### State Store
+- ### State Store
 
     A system for storing versioned, immutable Desired States that provides access control and auditing on the changes to the Desired State. Git may be configured as a State Store, but [special precautions must be taken](recipes/SETTING_UP_GIT.md).

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -29,11 +29,6 @@ These principles were derived from modern software operations but are rooted in 
 
 ## Notes
 
-### Principle 3 Notes
-
-- These differences could be due to the actual state drifting from the desired state, or the desired state changing intentionally.
-- The source of drift doesn't matter. Contrary to CIops, _any_ drift will trigger a reconciliation
-
 ### Principle 4 Notes
 
 - We talk here about "regular operations." In an emergency, other modes of operations, e.g. manual intervention, should be considered - followed by a reconciliation of the "tainted" system with the declared state. → resolve the conflict between "GitOps principle" and "I need to deal with problems that GitOps doesn't cover"
@@ -51,6 +46,16 @@ These principles were derived from modern software operations but are rooted in 
 - ### Desired State
 
     The aggregate of all configuration data for a system form its _Desired State_ which is defined as data sufficient to recreate the system so that instances of the system are behaviourally indistinguishable.
+
+- ### Drift
+
+    When a system's _Actual State_ changes for any reason other than its versioned _Desired State_ declarations having changed, we say that the system has drifted from it's _Desired State_.
+
+- ### Reconciliation
+
+    The process of ensuring that the _Actual State_ of a sytem matches it's versioned _Desired State_ declarations.
+    Contrary to CIops, any divergence between the two will trigger reconciliation, regardless of where changes occured.
+    Divergence could be due to the actual state unintentionally _Drifting_ from the desired state declarations, or a new desired state declaration version having been changed intentionally.
 
 - ### Software System
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -27,13 +27,14 @@ These principles were derived from modern software operations but are rooted in 
 
     The only mechanism through which the system is intentionally operated on is through these principles.
 
-## Notes
-
-### Principle 4 Notes
-
-- We talk here about "regular operations." In an emergency, other modes of operations, e.g. manual intervention, should be considered - followed by a reconciliation of the "tainted" system with the declared state. → resolve the conflict between "GitOps principle" and "I need to deal with problems that GitOps doesn't cover"
-
 ## Glossary
+
+- ### Break Glass
+
+    The temporary suspension of GitOps principles, most often pausing automated _Reconciliation_.
+    While these principles apply to "regular operations," it may sometimes be necessary to pause or sidestep them during an emergency such as incident management.
+    In these cases, other modes of operations should be considered (e.g. manual intervention), followed by any necessary updates to the desired state declarations, and finally resuming reconciliation of the manually changed system with the updated declarations again.
+    Pragmatic exceptions to these guiding principles are expected from time to time during the journey toward a system being fully managed by GitOps.
 
 - ### Continuous
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -67,4 +67,7 @@ These principles were derived from modern software operations but are rooted in 
 
 - ### State Store
 
-    A system for storing versioned, immutable Desired States that provides access control and auditing on the changes to the Desired State. Git may be configured as a State Store, but [special precautions must be taken](recipes/SETTING_UP_GIT.md).
+    A system for storing immutable versions of _Desired State_ declarations.
+    This state store should provide access control and auditing on the changes to the Desired State.
+    Git is most often used as this State Store, but other systems may be used.
+    In all cases these must be properly configured, and special precautions must be taken, to comply with requirements set out in the GitOps Principles.


### PR DESCRIPTION
- Fixes #11 
- Brings back only notes-related commits from #12 

Note this is identified as a blocker for the ~[v1.0.0 milestone](https://github.com/open-gitops/documents/milestone/1)~ [v1.0.0-rc.1 milestone](https://github.com/open-gitops/documents/milestone/6).