### PR TITLE
Introducing Break the Glass into principles...

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -52,5 +52,4 @@ This glossary accompanies the [GitOps Principles](./PRINCIPLES.md), and other su
         
 - ## Break the Glass
 
-    The practice of editing the Intermediate State Store directly in the event that a configuration update needs to be made to the Software System but the State Store is unavailable.
-
+    The process of editing the Intermediate State Store directly in the event that a configuration update needs to be made to the Software System but the State Store is unavailable.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -23,4 +23,4 @@ The [desired state](./GLOSSARY.md#desired-state) of a GitOps managed system must
     
 5. **Manageable "always"**
 
-    Desired state is updateable according to users' SLA expectations to update system state, even if the "source" is unavailable. 
+    Desired state is able to be updated according to users' SLA expectations to update system state, even if the "source" is unavailable. 


### PR DESCRIPTION
We (Morgan Stanley) believe that the situation where the source of truth for desired state (e.g. github.com or a git-equivalent that an enterprise may run) is less available than your users' expected SLA for making configuration changes is being left by the community as an issue for the implementer to overcome.

Put succinctly, if Github is unavailable and you want to make changes to your System State, there should be one approach and a set of tooling to allow reconciliation after the fact.

This will both harm adoption of gitops and is inefficient as I believe we shared a common challenge that we can solve once within the project.

The first step, as this project has so well established, is a glossary of terms to allow us to describe the problem and a draft principle to add. I have included these in this PR.