### PR TITLE
Introducing break the glass as a principle

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -40,7 +40,14 @@ This glossary accompanies the [GitOps Principles](./PRINCIPLES.md), and other su
     Git, from which GitOps derives its name, is the canonical example used as this state store but any other system that meets these criteria may be used.
     In all cases, these state stores must be properly configured and precautions must be taken to comply with requirements set out in the GitOps Principles.
 
+- ## Intermediate State Store
+    A system for storing a copy of the declarations that are mastered in the State Store. This system's purpose is intended to bridge the gap in availability between that of the State Store and the expected availability to make configuration changes to the Software System. The Intermediate State Store will offer an availability the same as or near enough to that of the users' expectations to update configuration in the Software System.
+
+Where an Intermediate State Store is used, Reconciliation is used between the State Store and the Intermediate State Store and then again between the Intermediate State Store and the Software System.![image](https://user-images.githubusercontent.com/7180729/137037872-934eba46-31a5-4509-a6cd-78aaf5bcbc63.png)
+
 - ## Feedback
 
     Open GitOps follows [control-theory](https://en.wikipedia.org/wiki/Control_theory) and operates in a closed-loop. In control theory, feedback represents how previous attempts to apply a desired state have affected the actual state. For example if the desired state requires more resources than exist in a system, the software agent may make attempts to add resources, to automatically rollback to a previous version, or to send alerts to human operators.
 
+- ## Break the Glass
+The process of editing the Intermediate State Store directly in the event that a configuration update needs to be made to the Software System but the State Store is unavailable.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -49,4 +49,4 @@ This glossary accompanies the [GitOps Principles](./PRINCIPLES.md), and other su
     Open GitOps follows [control-theory](https://en.wikipedia.org/wiki/Control_theory) and operates in a closed-loop. In control theory, feedback represents how previous attempts to apply a desired state have affected the actual state. For example if the desired state requires more resources than exist in a system, the software agent may make attempts to add resources, to automatically rollback to a previous version, or to send alerts to human operators.
 
 - ## Break the Glass
-The process of editing the Intermediate State Store directly in the event that a configuration update needs to be made to the Software System but the State Store is unavailable.
+    The process of editing the Intermediate State Store directly in the event that a configuration update needs to be made to the Software System but the State Store is unavailable.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -42,8 +42,7 @@ This glossary accompanies the [GitOps Principles](./PRINCIPLES.md), and other su
 
 - ## Intermediate State Store
     A system for storing a copy of the declarations that are mastered in the State Store. This system's purpose is intended to bridge the gap in availability between that of the State Store and the expected availability to make configuration changes to the Software System. The Intermediate State Store will offer an availability the same as or near enough to that of the users' expectations to update configuration in the Software System.
-
-Where an Intermediate State Store is used, Reconciliation is used between the State Store and the Intermediate State Store and then again between the Intermediate State Store and the Software System.
+    Where an Intermediate State Store is used, Reconciliation is used between the State Store and the Intermediate State Store and then again between the Intermediate State Store and the Software System.
 
 - ## Feedback
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -43,7 +43,7 @@ This glossary accompanies the [GitOps Principles](./PRINCIPLES.md), and other su
 - ## Intermediate State Store
     A system for storing a copy of the declarations that are mastered in the State Store. This system's purpose is intended to bridge the gap in availability between that of the State Store and the expected availability to make configuration changes to the Software System. The Intermediate State Store will offer an availability the same as or near enough to that of the users' expectations to update configuration in the Software System.
 
-Where an Intermediate State Store is used, Reconciliation is used between the State Store and the Intermediate State Store and then again between the Intermediate State Store and the Software System.![image](https://user-images.githubusercontent.com/7180729/137037872-934eba46-31a5-4509-a6cd-78aaf5bcbc63.png)
+Where an Intermediate State Store is used, Reconciliation is used between the State Store and the Intermediate State Store and then again between the Intermediate State Store and the Software System.
 
 - ## Feedback
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -21,6 +21,6 @@ The [desired state](./GLOSSARY.md#desired-state) of a GitOps managed system must
 
     Software agents [continuously](./GLOSSARY.md#continuous) observe actual system state and [attempt to apply](./GLOSSARY.md#reconciliation) the desired state.
     
-5. **Manageable "always"**
+5. **Actual System State is Manageable "always"**
 
-    Desired state is able to be updated according to users' SLA expectations to update system state, even if the "source" is unavailable. 
+    System state must still be manageable to users' SLA expectations to make changes. If the desired state store's availability is less that that SLA expectation, it should be possible to "break the glass" to update the system state directly and reconcile system state to desire state.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -23,4 +23,4 @@ The [desired state](./GLOSSARY.md#desired-state) of a GitOps managed system must
     
 5. **Actual System State is Manageable "always"**
 
-    System state must still be manageable to users' SLA expectations to make changes. If the desired state store's availability is less that that SLA expectation, it should be possible to "break the glass" to update the system state directly and reconcile system state to desire state.
+    System state manageability must meet users' SLA expectations to make changes to it. If the desired state store's availability is less that that SLA expectation, it should be possible to "break the glass" to update the system state directly and reconcile system state to desire state.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -21,3 +21,6 @@ The [desired state](./GLOSSARY.md#desired-state) of a GitOps managed system must
 
     Software agents [continuously](./GLOSSARY.md#continuous) observe actual system state and [attempt to apply](./GLOSSARY.md#reconciliation) the desired state.
     
+5. **Manageable "always"**
+
+    Desired state is able to be updated according to users' SLA expectations to update system state, even if the "source" is unavailable. 


### PR DESCRIPTION
We (representing Morgan Stanley) believe that the situation where the source of truth for desired state (e.g. github.com or a git-equivalent that an enterprise may run - but recognizing there are central and decentralized approaches for storing desired state) is less available than your users' expected SLA for making configuration changes is being left by the community as an issue for the implementer to overcome.
Put succinctly, if (in our example) Github is unavailable and you want to make changes to your System State, there should be one approach and a set of tooling to allow reconciliation after the fact. A further example exists in disconnected systems (e.g. Kubernetes on a ship) where the system may be disconnected from the store where the desired state resides. How then would the system state be updated in an emergency and then reconciled with the desired state?
This will both harm adoption of gitops and is inefficient as I believe we shared a common challenge that we can solve once within the project.
The first step, as this project has so well established, is a glossary of terms to allow us to describe the problem and a draft principle to add. I have included these in this PR.