### PR TITLE
1:1 Repo structure Proposal

### DIFF
--- a/repo-structure/README.md
+++ b/repo-structure/README.md
@@ -1,0 +1,17 @@
+# GitOps Repository Examples
+
+Here, you can find examples of how you can layout your GitOps directory
+structure. These are less about creating a definition on how it should
+be done, but more about how you can get started.
+
+Creating a directory structure for your
+organization will always end up falling into [Conway's
+Law](https://en.wikipedia.org/wiki/Conway%27s_law). Still, there are
+best practices that can be followed to help guide you.
+
+These examples are meant as a starting point, and not the end goal.
+
+* [1:1 Repo](./one-to-one) - This repo structure is based on one-repo that manages one-cluster.
+* [1:X Repo]() - This repo structure is one-repo to many-clusters (also called "mono-repo")
+* [X:1 Repo]() - This structure is many-repos deploying to one-cluster
+* [X:X]() - This implementation is many-repos deploying to many-clusters. This is also where "fan-out" design lands.

--- a/repo-structure/one-to-one/README.md
+++ b/repo-structure/one-to-one/README.md
@@ -1,0 +1,53 @@
+# Flux Example
+
+This is an example on how to structure a GitOps repo using the [1:1
+method](../) and Argo CD. This is meant as a good starting point and
+not what your final repo will look like.
+
+# Structure
+
+Below is an explanation on how this repo is laid out. You'll notice
+[Kustomize](https://kustomize.io/) is used heavily. This is to follow the
+[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principal
+when it comes to YAML files.
+
+```shell
+cluster-XXXX/ #1
+├── bootstrap #2
+│   ├── base
+│   └── overlays
+│       └── default
+├── components #3
+│   ├── (applicationsets OR kustomizations)
+│   └── (argocdproj OR gitrepositories)
+├── core #4
+│   ├── gitops-controller
+│   └── sample-admin-workload
+└── tenants
+    ├── bgd-blue
+    └── myapp
+```
+
+|#|Directory Name|Description|
+|---|----------------|-----------------|
+| 1. |`cluster-XXXX`| This is the cluster name and top level directory in your repo. This name should be unique to the specific cluster you're targeting. If you're using CAPI, this should be the name of your cluster, the output of `kubectl get cluster`|
+| 2. | `bootstrap` | This is where bootstrapping specifc configurations are stored. These are items that get the cluster/automation started. They are usually install manifests of the GitOps controller.<br /><br />`base` is where are the "common" YAML would live and `overlays` are configurations specific to the cluster.<br /><br />The `kustomization.yaml` file in `default` has all the directories under `cluster-XXXX/components/` as a part of it's `bases` config.|
+| 3. | `components` | This is where specific components for the GitOps Controller lives. The directories here depend on the GitOps controller you are using.<br /><br /> For example, if you're using Argo CD, `applicationsets` and `argocdproj` are possible directories (each in their repsective configurations). For Flux, this is where `gitrepositories` and `kustomizations` (with their repsective configurations) would be stored.|
+| 4. | `core` | This is where YAML for the core functionality of the cluster live. These are things that are necissary for the cluster to run/be usable. Here is where the Kubernetes administrator will put things that is necissary for the functionality of the cluster (like cluster configs or cluster workloads).<br /><br />Under `gitops-controller` is where you are using the GitOps controller to manage itself. The `kustomization.yaml` file uses `cluster-XXXX/bootstrap/overlays/default` in it's `bases` configuration. This `core` directory gets deployed as a workload.<br /><br />To add a new "core functionality" workoad, one needs to add a directory with some yaml in the `core` directory. See the `sample-admin-config` directory as an example.|
+| 5. | `tenants` | This is where the workloads for this cluster live.<br /><br />Similar to `core`, all directories under `tenants` gets deployed .<br /><br />This is where Devlopers/Release Engineers do the work. They just need to commit a directory with some YAML and the GitOps controller takes care of creating the workload.<br /><br /> **Note** that `bgd-blue/kustomization.yaml` file points to another Git repo. This is to show that you can host your YAML in one repo, or many repos, while still keeping one repo to manage the one cluster.|
+
+# Noteworthy Things
+
+Some of this layout may seem "overkill" for a single cluster, but there are reasons. 
+
+* The `bootstrap` seems redundant as you are just referencing it in the `gitops-controller` directory. This is to "instill good habits" as the `bootstrap` directory comes in handly later when you're doing mono-repo (1 repo to many clusters).
+* It may seem redundant to have `core` and `tenants`. You can fold this into one directory called `apps` because, functionally, `core` and `tenants` are the same thing. However, this is done (separating the two) as a way to set a demarcation between what "is needed in the cluster" and "what is using the cluster".
+* There is an `overlays/default` directory for the same reason as there is `bootstrap` directory. Instilling good habits. This is, technically, unecissary for the functionality; but it's an important practice for other designs/implementations.
+
+# Examples
+
+You'll find the following examples using this structure in this repo:
+
+* [Argo CD Example](argocd-example)
+* [Flux Example](flux-example)
+* [OpenShift GitOps Example](openshift-gitops-example)

--- a/repo-structure/one-to-one/README.md
+++ b/repo-structure/one-to-one/README.md
@@ -1,8 +1,10 @@
-# Flux Example
+# One to One GitOps Repository
 
-This is an example on how to structure a GitOps repo using the [1:1
-method](../) and Argo CD. This is meant as a good starting point and
-not what your final repo will look like.
+This is an example on how to structure a GitOps repo using the "One repo
+per cluster" method. This is meant to be a "generic" way of doing this
+that should fit most GitOps controllers.
+
+This is meant as a good starting point, but not how your final layout will look like.
 
 # Structure
 

--- a/repo-structure/one-to-one/argocd-example/README.md
+++ b/repo-structure/one-to-one/argocd-example/README.md
@@ -1,0 +1,106 @@
+# Argo CD Example
+
+This is an example on how to structure a GitOps repo using the [1:1
+method](../) and Argo CD. This is meant as a good starting point and
+not what your final repo will look like.
+
+# Structure
+
+Below is an explanation on how this repo is laid out. You'll notice
+that [Kustomize](https://kustomize.io/) is used heavily. This follows the
+[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principal
+when it comes to YAML files.
+
+```shell
+cluster-XXXX/ # 1
+├── bootstrap # 2
+│   ├── base
+│   │   ├── argocd-ns.yaml
+│   │   └── kustomization.yaml
+│   └── overlays
+│       └── default
+│           └── kustomization.yaml
+├── components # 3
+│   ├── applicationsets
+│   │   ├── core-components-appset.yaml
+│   │   ├── kustomization.yaml
+│   │   └── tenants-appset.yaml
+│   └── argocdproj
+│       ├── kustomization.yaml
+│       └── test-project.yaml
+├── core # 4
+│   ├── gitops-controller
+│   │   └── kustomization.yaml
+│   └── sample-admin-config
+│       ├── kustomization.yaml
+│       └── sample-admin-config.yaml
+└── tenants # 5
+    ├── bgd-blue
+    │   ├── bgd-deployment.yaml
+    │   └── kustomization.yaml
+    └── myapp
+        ├── kustomization.yaml
+        ├── myapp-deployment.yaml
+        ├── myapp-ns.yaml
+        └── myapp-service.yaml
+```
+
+|#|Directory Name|Description|
+|---|----------------|-----------------|
+| 1. |`cluster-XXXX`| This is the cluster name. This name should be unique to the specific cluster you're targeting. If you're using CAPI, this should be the name of your cluster, the output of `kubectl get cluster`|
+| 2. | `bootstrap` | This is where bootstrapping specifc configurations are stored. These are items that get the cluster/automation started. They are usually install manifests.<br /><br />`base` is where are the "common" YAML would live and `overlays` are configurations specific to the cluster.<br /><br />The `kustomization.yaml` file in `default` has `cluster-XXXX/components/applicationsets/` and `cluster-XXXX/components/argocdproj/` as a part of it's `bases` config.|
+| 3. | `components` | This is where specific components for the GitOps Controller lives (in this case Argo CD).<br /><br />`applicationsets` is where all the ApplicationSets YAMLs live and `argocdproj` is where the ArgoAppProject YAMLs live.<br /><br />Other things that can live here are RBAC, Git repo, and other Argo CD specific configurations (each in their repsective directories).|
+| 4. | `core` | This is where YAML for the core functionality of the cluster live. Here is where the Kubernetes administrator will put things that is necissary for the functionality of the cluster (like cluster configs or cluster workloads).<br /><br />Under `gitops-controller` is where you are using Argo CD to manage itself. The `kustomization.yaml` file uses `cluster-XXXX/bootstrap/overlays/default` in it's `bases` configuration. This `core` directory gets deployed as an applicationset which can be found under `cluster-XXXX/components/applicationsets/core-components-appset.yaml`.<br /><br />To add a new "core functionality" workoad, one needs to add a directory with some yaml in the `core` directory. See the `sample-admin-config` directory as an example.|
+| 5. | `tenants` | This is where the workloads for this cluster live.<br /><br />Similar to `core`, the `tenants` directory gets loaded as part of an ApplicationSet that is under `cluster-XXXX/components/applicationsets/tenants-appset.yaml`.<br /><br />This is where Devlopers/Release Engineers do the work. They just need to commit a directory with some YAML and the applicationset takes care of creating the workload.<br /><br /> **Note** that `bgd-blue/kustomization.yaml` file points to another Git repo. This is to show that you can host your YAML in one repo, or many repos.|
+
+# Testing
+
+To see this in action, first get yourself a cluster (using [kind](kind.sigs.k8s.io/) as an example)
+
+```shell
+kind create cluster
+```
+
+Afer cloning this repo just apply the overlay directory
+
+```shell
+until kubectl apply -k repo-structure/one-to-one/argocd-example/cluster-XXXX/bootstrap/overlays/default/; do sleep 3; done
+```
+
+This should give you 4 applications
+
+```shell
+$ kubectl get applications -n argocd
+NAME                          SYNC STATUS   HEALTH STATUS
+bgd-blue                      Synced        Healthy
+sample-admin-workload         Synced        Healthy
+myapp                         Synced        Healthy
+gitops-controller             Synced        Healthy
+```
+
+Backed by 2 applicationsets
+
+```shell
+$ kubectl get appsets -n argocd
+NAME      AGE
+cluster   110s
+tenants   110s
+```
+
+To see the Argo CD UI, you'll first need the password
+
+```shell
+kubectl get secret/argocd-initial-admin-secret -n argocd -o jsonpath='{.data.password}' | base64 -d ; echo
+```
+
+Then port-forward to see it in your browser (using `admin` as the username).
+
+```shell
+kubectl -n argocd port-forward service/argocd-server 8080:443
+```
+
+# Enjoy
+
+Fork and Enjoy!
+
+> :warning: Feel free to fork this and play around with it, but remember if you'll have to change the applicationsets configuration and where the bases are pointing to if you're chanigng names of things

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/bootstrap/base/argocd-ns.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/bootstrap/base/argocd-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+spec: {}
+status: {}

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/bootstrap/base/kustomization.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/bootstrap/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- argocd-ns.yaml
+- https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+- https://raw.githubusercontent.com/argoproj-labs/applicationset/stable/manifests/install.yaml

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/bootstrap/overlays/default/kustomization.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/bootstrap/overlays/default/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+
+bases:
+- ../../base
+- ../../../components/applicationsets
+- ../../../components/argocdproj

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/applicationsets/core-components-appset.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/applicationsets/core-components-appset.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster
+  namespace: argocd
+spec:
+  generators:
+  - git:
+      repoURL: https://github.com/open-gitops/documents
+      revision: main
+      directories:
+      - path: repo-structure/one-to-one/argocd-example/cluster-XXXX/core/*
+  template:
+    metadata:
+      name: '{{path.basename}}'
+    spec:
+      project: default
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: 15
+          backoff:
+            duration: 15s
+            factor: 2
+            maxDuration: 5m
+      source:
+        repoURL: https://github.com/open-gitops/documents
+        targetRevision: main
+        path: '{{path}}'
+      destination:
+        server: https://kubernetes.default.svc

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/applicationsets/kustomization.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/applicationsets/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- core-components-appset.yaml
+- tenants-appset.yaml

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/applicationsets/tenants-appset.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/applicationsets/tenants-appset.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tenants
+  namespace: argocd
+spec:
+  generators:
+  - git:
+      repoURL: https://github.com/open-gitops/documents
+      revision: main
+      directories:
+      - path: repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/*
+  template:
+    metadata:
+      name: '{{path.basename}}'
+    spec:
+      project: default
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: 15
+          backoff:
+            duration: 15s
+            factor: 2
+            maxDuration: 5m
+      source:
+        repoURL: https://github.com/open-gitops/documents
+        targetRevision: main
+        path: '{{path}}'
+      destination:
+        server: https://kubernetes.default.svc

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/argocdproj/kustomization.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/argocdproj/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- test-project.yaml

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/argocdproj/test-project.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/components/argocdproj/test-project.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: test-project
+  namespace: argocd
+spec: {}

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/core/gitops-controller/kustomization.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/core/gitops-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../bootstrap/overlays/default/
+

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/core/sample-admin-workload/kustomization.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/core/sample-admin-workload/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+
+resources: 
+- sample-admin-config.yaml

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/core/sample-admin-workload/sample-admin-config.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/core/sample-admin-workload/sample-admin-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cskb-config
+data:
+  csbk.config: |
+    cool=yes

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/bgd-blue/bgd-deployment.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/bgd-blue/bgd-deployment.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/replicas
+  value: 3

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/bgd-blue/kustomization.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/bgd-blue/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- https://gitlab.com/christianh814/test-applicationsets/list-generator/k8s/overlays/noing-blue?ref=main
+
+patchesJson6902:
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: bgd
+    path: bgd-deployment.yaml

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/myapp/kustomization.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/myapp/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- myapp-ns.yaml
+- myapp-deployment.yaml
+- myapp-service.yaml

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/myapp/myapp-deployment.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/myapp/myapp-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: welcome-php
+  name: welcome-php
+  namespace: foobar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: welcome-php
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: welcome-php
+    spec:
+      containers:
+      - image: quay.io/redhatworkshops/welcome-php
+        name: welcome-php
+        resources: {}
+status: {}

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/myapp/myapp-ns.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/myapp/myapp-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foobar
+spec: {}
+status: {}

--- a/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/myapp/myapp-service.yaml
+++ b/repo-structure/one-to-one/argocd-example/cluster-XXXX/tenants/myapp/myapp-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: welcome-php
+  name: welcome-php
+  namespace: foobar
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: welcome-php
+status:
+  loadBalancer: {}

--- a/repo-structure/one-to-one/flux-example/README.md
+++ b/repo-structure/one-to-one/flux-example/README.md
@@ -1,0 +1,97 @@
+# Flux Example
+
+This is an example on how to structure a GitOps repo using the [1:1
+method](../) and Flux. This is meant as a good starting point and
+not what your final repo will look like.
+
+# Structure
+
+Below is an explanation on how this repo is laid out. You'll notice
+that [Kustomize](https://kustomize.io/) is used heavily. This follows the
+[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principal
+when it comes to YAML files.
+
+```shell
+cluster-XXXX/ # 1
+├── bootstrap # 2
+│   ├── base
+│   │   └── kustomization.yaml
+│   └── overlays
+│       └── default
+│           └── kustomization.yaml
+├── components # 3
+│   ├── gitrepositories
+│   │   ├── cluster-gitrepo.yaml
+│   │   └── kustomization.yaml
+│   ├── helmreleases
+│   │   ├── kustomization.yaml
+│   │   └── sample-quarkus.yaml
+│   ├── helmrepositories
+│   │   ├── kustomization.yaml
+│   │   └── redhat-helm-charts.yaml
+│   └── kustomizations
+│       ├── core-components-kustomization.yaml
+│       ├── kustomization.yaml
+│       └── tenants-kustomization.yaml
+├── core # 4
+│   ├── gitops-controller
+│   │   └── kustomization.yaml
+│   └── sample-admin-workload
+│       ├── kustomization.yaml
+│       └── sample-admin-config.yaml
+└── tenants # 5
+    ├── bgd-blue
+    │   ├── bgd-deployment.yaml
+    │   └── kustomization.yaml
+    └── myapp
+        ├── kustomization.yaml
+        ├── myapp-deployment.yaml
+        ├── myapp-ns.yaml
+        └── myapp-service.yaml
+```
+
+|#|Directory Name|Description|
+|---|----------------|-----------------|
+| 1. |`cluster-XXXX`| This is the cluster name. This name should be unique to the specific cluster you're targeting. If you're using CAPI, this should be the name of your cluster, the output of `kubectl get cluster`|
+| 2. | `bootstrap` | This is where bootstrapping specifc configurations are stored. These are items that get the cluster/automation started. They are usually install manifests.<br /><br />`base` is where are the "common" YAML would live and `overlays` are configurations specific to the cluster.<br /><br />The `kustomization.yaml` file in `default` has `cluster-XXXX/components/gitrepositories/`, `cluster-XXXX/components/helmreleases`, `cluster-XXXX/components/helmrepositories` and `cluster-XXXX/components/kustomizations` as a part of it's `bases` config.|
+| 3. | `components` | This is where specific components for the GitOps Controller lives (in this case Flux) .<br /><br />`gitrepositories` is where all the configuration YAMLs to access this (and other) git repos live, `helmrepositories` is where the configuration for your helm repositories YAMLs live, `helmreleases` is where your HelmReleases live, and `kustomizations` are where Kustomizations for this cluster live.<br /><br />Other things that can live here are [other Flux components](https://fluxcd.io/docs/components/) (each in their repsective directories).|
+| 4. | `core` | This is where YAML for the core functionality of the cluster live. Here is where the Kubernetes administrator will put things that is necissary for the functionality of the cluster (like cluster configs or cluster workloads).<br /><br />Under `gitops-controller` is where you are using Flux to manage itself. The `kustomization.yaml` file uses `cluster-XXXX/bootstrap/overlays/default` in it's `bases` configuration. Everything in this `core` directory gets deployed as a part of the `kustomization` found under `cluster-XXXX/components/kustomizations/core-components-kustomization.yaml`.<br /><br />To add a new "core functionality" workoad, one needs to add a directory with some yaml in the `core` directory. See the `sample-admin-config` directory as an example.|
+| 5. | `tenants` | This is where the workloads for this cluster live.<br /><br />Similar to `core`, the `tenants` directory gets loaded as part of a `kustomization` that is under `cluster-XXXX/components/kustomizations/tenants-kustomization.yaml`.<br /><br />This is where Devlopers/Release Engineers do the work. They just need to commit a directory with some YAML and the kustomization takes care of creating the workload.<br /><br /> **Note** that `bgd-blue/kustomization.yaml` file points to another Git repo. This is to show that you can host your YAML in one repo, or many repos.|
+
+# Testing
+
+To see this in action, first get yourself a cluster (using [kind](kind.sigs.k8s.io/) as an example)
+
+```shell
+kind create cluster
+```
+
+Afer cloning this repo just apply the overlay directory
+
+```shell
+until kubectl apply -k repo-structure/one-to-one/flux-example/cluster-XXXX/bootstrap/overlays/default/; do sleep 3; done
+```
+
+This should give you 2 `kustomizations`
+
+```shell
+$ kubectl get kustomizations -n flux-system 
+NAME          READY   STATUS                                                            AGE
+core          True    Applied revision: main/111881dc371dd1b2abd823450f01ee085aff3726   3m50s
+tenants       True    Applied revision: main/111881dc371dd1b2abd823450f01ee085aff3726   3m50s
+```
+
+This should also load your git source
+
+```shell
+$ kubectl get gitrepositories -n flux-system
+NAME                   URL                                                               READY   STATUS                                                            AGE
+cluster-xxxx-gitrepo   https://github.com/open-gitops/documents   True    Fetched revision: main/111881dc371dd1b2abd823450f01ee085aff3726   4m25s
+```
+
+
+# Enjoy
+
+Fork and Enjoy!
+
+> :warning: Feel free to fork this and play around with it, but remember if you'll maybe have to change the where the bases are pointing to if you're changing names of things.

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/bootstrap/base/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/bootstrap/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/fluxcd/flux2/releases/latest/download/install.yaml

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/bootstrap/overlays/default/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/bootstrap/overlays/default/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../base
+- ../../../components/gitrepositories
+- ../../../components/helmrepositories
+- ../../../components/helmreleases
+- ../../../components/kustomizations

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/components/gitrepositories/cluster-gitrepo.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/components/gitrepositories/cluster-gitrepo.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: cluster-xxxx-gitrepo
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  url: https://github.com/open-gitops/documents

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/components/gitrepositories/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/components/gitrepositories/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cluster-gitrepo.yaml

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/components/helmreleases/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/components/helmreleases/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- sample-quarkus.yaml

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/components/helmreleases/sample-quarkus.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/components/helmreleases/sample-quarkus.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: sample
+  namespace: flux-system
+spec:
+  targetNamespace: quarkus
+  install:
+    createNamespace: true
+  chart:
+    spec:
+      chart: quarkus
+      version: 0.0.3
+      sourceRef:
+        kind: HelmRepository
+        name: redhat-helm-charts
+  values:
+    build:
+      enabled: false
+    deploy:
+      route:
+        enabled: false
+    image:
+      name: quay.io/ablock/gitops-helm-quarkus
+  interval: 1m0s

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/components/helmrepositories/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/components/helmrepositories/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- redhat-helm-charts.yaml

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/components/helmrepositories/redhat-helm-charts.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/components/helmrepositories/redhat-helm-charts.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: redhat-helm-charts
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  url: https://redhat-developer.github.io/redhat-helm-charts

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/components/kustomizations/core-components-kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/components/kustomizations/core-components-kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: core
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  path: ./repo-structure/one-to-one/flux-example/cluster-XXXX/core
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: cluster-xxxx-gitrepo

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/components/kustomizations/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/components/kustomizations/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- core-components-kustomization.yaml
+- tenants-kustomization.yaml

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/components/kustomizations/tenants-kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/components/kustomizations/tenants-kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: tenants
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  path: ./repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: cluster-xxxx-gitrepo

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/core/gitops-controller/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/core/gitops-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../bootstrap/overlays/default/
+

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/core/sample-admin-workload/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/core/sample-admin-workload/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+
+resources: 
+- sample-admin-config.yaml

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/core/sample-admin-workload/sample-admin-config.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/core/sample-admin-workload/sample-admin-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cskb-config
+data:
+  csbk.config: |
+    cool=yes

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/bgd-blue/bgd-deployment.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/bgd-blue/bgd-deployment.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/replicas
+  value: 3

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/bgd-blue/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/bgd-blue/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- https://gitlab.com/christianh814/test-applicationsets/list-generator/k8s/overlays/noing-blue?ref=main
+
+patchesJson6902:
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: bgd
+    path: bgd-deployment.yaml

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/myapp/kustomization.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/myapp/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- myapp-ns.yaml
+- myapp-deployment.yaml
+- myapp-service.yaml

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/myapp/myapp-deployment.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/myapp/myapp-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: welcome-php
+  name: welcome-php
+  namespace: foobar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: welcome-php
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: welcome-php
+    spec:
+      containers:
+      - image: quay.io/redhatworkshops/welcome-php
+        name: welcome-php
+        resources: {}
+status: {}

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/myapp/myapp-ns.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/myapp/myapp-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foobar
+spec: {}
+status: {}

--- a/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/myapp/myapp-service.yaml
+++ b/repo-structure/one-to-one/flux-example/cluster-XXXX/tenants/myapp/myapp-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: welcome-php
+  name: welcome-php
+  namespace: foobar
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: welcome-php
+status:
+  loadBalancer: {}

--- a/repo-structure/one-to-one/openshift-gitops-example/README.md
+++ b/repo-structure/one-to-one/openshift-gitops-example/README.md
@@ -1,0 +1,107 @@
+# OpenShift GitOps Example
+
+This is an example on how to structure a GitOps repo using the [1:1
+method](../) and OpenShift. This is meant as a good starting point and
+not what your final repo will look like.
+
+Although OpenShift uses Argo CD,
+this example was necissary because OpenShift uses
+[OLM](https://docs.openshift.com/container-platform/latest/operators/understanding/olm/olm-understanding-olm.html)
+for installation of it's component
+
+# Structure
+
+Below is an explanation on how this repo is laid out. You'll notice
+that [Kustomize](https://kustomize.io/) is used heavily. This follows the
+[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principal
+when it comes to YAML files.
+
+```shell
+cluster-XXXX/ # 1
+├── bootstrap # 2
+│   ├── base
+│   │   ├── kustomization.yaml
+│   │   └── openshift-gitops-sub.yaml
+│   └── overlays
+│       └── default
+│           ├── kustomization.yaml
+│           ├── openshift-gitops-argocd.yaml
+│           └── openshift-gitops-rbac-policy.yaml
+├── components # 3
+│   ├── applicationsets
+│   │   ├── core-components-appset.yaml
+│   │   ├── kustomization.yaml
+│   │   └── tenants-appset.yaml
+│   └── argocdproj
+│       ├── kustomization.yaml
+│       └── test-project.yaml
+├── core # 4
+│   ├── container-security-operator
+│   │   ├── container-security-operator-sub.yaml
+│   │   └── kustomization.yaml
+│   └── gitops-controller
+│       └── kustomization.yaml
+└── tenants # 5
+    ├── bgd-blue
+    │   ├── bgd-deployment.yaml
+    │   └── kustomization.yaml
+    └── myapp
+        ├── kustomization.yaml
+        ├── myapp-deployment.yaml
+        ├── myapp-ns.yaml
+        ├── myapp-route.yaml
+        └── myapp-service.yaml
+```
+|#|Directory Name|Description|
+|---|----------------|-----------------|
+| 1. |`cluster-XXXX`| This is the cluster name. This name should be unique to the specific cluster you're targeting. For OpenShift, use the output of `kubectl get infrastructure cluster -o jsonpath='{.status.infrastructureName}'`|
+| 2. | `bootstrap` | This is where bootstrapping specifc configurations are stored. These are items that get the cluster/automation started. They are usually install manifests.<br /><br /> `base` is where are the "common" YAML would live and `overlays` are configurations specific to the cluster.<br /><br />The `kustomization.yaml` file in `default` overlay has `cluster-XXXX/components/applicationsets/` and `cluster-XXXX/components/argocdproj/` as a part of it's `bases` config.|
+| 3. | `components` | This is where specific components for the GitOps Controller lives (in this case Argo CD).<br /><br />`applicationsets` is where all the ApplicationSets YAMLs live and `argocdproj` is where the ArgoAppProject YAMLs live.<br /><br />Other things that can live here are RBAC, Git repo, and other Argo CD specific configurations (each in their repsective directories).|
+| 4. | `core` | This is where YAML for the core functionality of the cluster live. Here is where the Kubernetes administrator will put things that is necissary for the functionality of the cluster.<br /><br />Under `gitops-controller` is where you are using Argo CD to manage itself. The `kustomization.yaml` file uses `cluster-XXXX/bootstrap/overlays/default` in it's `bases` configuration. This `core` directory gets deployed as an applicationset which can be found under `cluster-XXXX/components/applicationsets/core-components-appset.yaml`.<br /><br />To add a new "core functionality" workload, one needs to add a directory with some yaml in the `core` directory. See the `container-security-operator` directory as an example.|
+| 5. | `tenants` | This is where the workloads for this cluster live.<br /><br />Similar to `core`, the `tenants` directory gets loaded as part of an ApplicationSet that is under `cluster-XXXX/components/applicationsets/tenants-appset.yaml`.<br /><br />This is where Devlopers/Release Engineers do the work. They just need to commit a directory with some YAML and the applicationset takes care of creating the workload.<br /><br />**Note** that `bgd-blue/kustomization.yaml` file points to another Git repo. This is to show that you can host your YAML in one repo, or many repos.|
+
+# Testing
+
+Install OpenShift using:
+
+```shell
+openshift-install create cluster
+```
+
+Afer cloning this repo just apply the overlay directory
+
+```shell
+until kubectl apply -k repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/overlays/default/; do sleep 3; done
+```
+
+This should give you 4 applications
+
+```shell
+$ kubectl get applications -n openshift-gitops
+NAME                          SYNC STATUS   HEALTH STATUS
+bgd-blue                      Synced        Healthy
+container-security-operator   Synced        Healthy
+myapp                         Synced        Healthy
+gitops-controller             Synced        Healthy
+```
+
+Backed by 2 applicationsets
+
+```shell
+$ kubectl get appsets -n openshift-gitops
+NAME      AGE
+cluster   110s
+tenants   110s
+```
+
+Visit the Argo CD UI to see it visualized, get the route by running (use "LOG IN VIA OPENSHIFT"):
+
+```shell
+kubectl get route openshift-gitops-server -n openshift-gitops -o jsonpath='{.spec.host}{"\n"}'
+```
+
+# Enjoy
+
+Fork and Enjoy
+
+> :warning: Feel free to fork this and play around with it, but remember if you'll have to change the applicationsets configuration and where the bases are pointing to if you're chanigng names of things

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/base/kustomization.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- openshift-gitops-sub.yaml

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/base/openshift-gitops-sub.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/base/openshift-gitops-sub.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/overlays/default/kustomization.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/overlays/default/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../base
+- ../../../components/applicationsets
+- ../../../components/argocdproj
+
+resources:
+- openshift-gitops-argocd.yaml
+- openshift-gitops-rbac-policy.yaml

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/overlays/default/openshift-gitops-argocd.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/overlays/default/openshift-gitops-argocd.yaml
@@ -1,0 +1,125 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  applicationSet:
+    resources:
+      limits:
+        cpu: "2"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+  controller:
+    processors: {}
+    resources:
+      limits:
+        cpu: "2"
+        memory: 2Gi
+      requests:
+        cpu: 250m
+        memory: 1Gi
+    sharding: {}
+  dex:
+    openShiftOAuth: true
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  grafana:
+    enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+    route:
+      enabled: false
+  ha:
+    enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  initialSSHKnownHosts: {}
+  prometheus:
+    enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: false
+  rbac:
+    policy: g, system:cluster-admins, role:admin
+    scopes: '[groups]'
+  redis:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  repo:
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  resourceCustomizations: |
+    bitnami.com/SealedSecret:
+      health.lua: |
+        hs = {}
+        hs.status = "Healthy"
+        hs.message = "Controller doesnt report status"
+        return hs
+    route.openshift.io/Route:
+      ignoreDifferences: |
+        jsonPointers:
+        - /spec/host
+  resourceExclusions: |
+    - apiGroups:
+      - tekton.dev
+      clusters:
+      - '*'
+      kinds:
+      - TaskRun
+      - PipelineRun
+  server:
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    ingress:
+      enabled: false
+    insecure: true
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    route:
+      enabled: true
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: edge
+    service:
+      type: ""
+  tls:
+    ca: {}

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/overlays/default/openshift-gitops-rbac-policy.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/bootstrap/overlays/default/openshift-gitops-rbac-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-admin-for-osgo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/applicationsets/core-components-appset.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/applicationsets/core-components-appset.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster
+  namespace: openshift-gitops
+spec:
+  generators:
+  - git:
+      repoURL: https://github.com/open-gitops/documents
+      revision: main
+      directories:
+      - path: repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/core/*
+  template:
+    metadata:
+      name: '{{path.basename}}'
+    spec:
+      project: default
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: 15
+          backoff:
+            duration: 15s
+            factor: 2
+            maxDuration: 5m
+      source:
+        repoURL: https://github.com/open-gitops/documents
+        targetRevision: main
+        path: '{{path}}'
+      destination:
+        server: https://kubernetes.default.svc

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/applicationsets/kustomization.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/applicationsets/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- core-components-appset.yaml
+- tenants-appset.yaml

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/applicationsets/tenants-appset.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/applicationsets/tenants-appset.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tenants
+  namespace: openshift-gitops
+spec:
+  generators:
+  - git:
+      repoURL: https://github.com/open-gitops/documents
+      revision: main
+      directories:
+      - path: repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/*
+  template:
+    metadata:
+      name: '{{path.basename}}'
+    spec:
+      project: default
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: 15
+          backoff:
+            duration: 15s
+            factor: 2
+            maxDuration: 5m
+      source:
+        repoURL: https://github.com/open-gitops/documents
+        targetRevision: main
+        path: '{{path}}'
+      destination:
+        server: https://kubernetes.default.svc

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/argocdproj/kustomization.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/argocdproj/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- test-project.yaml

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/argocdproj/test-project.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/components/argocdproj/test-project.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: test-project
+  namespace: openshift-gitops
+spec: {}

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/core/container-security-operator/container-security-operator-sub.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/core/container-security-operator/container-security-operator-sub.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: container-security-operator
+  namespace: openshift-operators
+spec:
+  channel: quay-v3.3
+  installPlanApproval: Automatic
+  name: container-security-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/core/container-security-operator/kustomization.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/core/container-security-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources: 
+- container-security-operator-sub.yaml

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/core/gitops-controller/kustomization.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/core/gitops-controller/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../bootstrap/overlays/default/
+

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/bgd-blue/bgd-deployment.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/bgd-blue/bgd-deployment.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/replicas
+  value: 3

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/bgd-blue/kustomization.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/bgd-blue/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- https://gitlab.com/christianh814/test-applicationsets/list-generator/ocp/overlays/blue?ref=main
+
+patchesJson6902:
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: bgd
+    path: bgd-deployment.yaml

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/kustomization.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- myapp-ns.yaml
+- myapp-deployment.yaml
+- myapp-service.yaml
+- myapp-route.yaml

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/myapp-deployment.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/myapp-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: welcome-php
+  name: welcome-php
+  namespace: foobar
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: welcome-php
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: welcome-php
+    spec:
+      containers:
+      - image: quay.io/redhatworkshops/welcome-php
+        name: welcome-php
+        resources: {}
+status: {}

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/myapp-ns.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/myapp-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foobar
+spec: {}
+status: {}

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/myapp-route.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/myapp-route.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: welcome-php
+    app.kubernetes.io/instance: myapp
+  name: welcome-php
+  namespace: foobar
+spec:
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: welcome-php
+    weight: 100
+status: {}

--- a/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/myapp-service.yaml
+++ b/repo-structure/one-to-one/openshift-gitops-example/cluster-XXXX/tenants/myapp/myapp-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: welcome-php
+  name: welcome-php
+  namespace: foobar
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: welcome-php
+status:
+  loadBalancer: {}


### PR DESCRIPTION
# Repo Structure Best Practices Proposal

I decided to throw my hat in the ring and start the conversation around getting best practices around repo structures.

I am starting with the "One repo for one cluster" design, as it's the easiest. I tried to go with a design that I've seen a lot of with my dealings out with end users while keeping it GitOps controller agnostic (i.e. it should work with Argo CD, Flux, Open Cluster Managment, etc).

This PR also comes with some examples as well.

For background/more context; I went over this on my stream [HERE](https://www.youtube.com/watch?v=mKiWTtUF1u8&list=PLaR6Rq6Z4IqfGCkI28cUMbNhPhsnj4nq3&index=1) and [HERE](https://www.youtube.com/watch?v=HDg5vh97zmI&list=PLaR6Rq6Z4IqfGCkI28cUMbNhPhsnj4nq3&index=9&t=380s)

# Structure

Below is an explanation on how this repo is laid out. You'll notice
[Kustomize](https://kustomize.io/) is used heavily. This is to follow the
[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principal
when it comes to YAML files.

```shell
cluster-XXXX/ #1
├── bootstrap #2
│   ├── base
│   └── overlays
│       └── default
├── components #3
│   ├── (applicationsets OR kustomizations)
│   └── (argocdproj OR gitrepositories)
├── core #4
│   ├── gitops-controller
│   └── sample-admin-workload
└── tenants
    ├── bgd-blue
    └── myapp
```

|#|Directory Name|Description|
|---|----------------|-----------------|
| 1. |`cluster-XXXX`| This is the cluster name and top level directory in your repo. This name should be unique to the specific cluster you're targeting. If you're using CAPI, this should be the name of your cluster, the output of `kubectl get cluster`|
| 2. | `bootstrap` | This is where bootstrapping specifc configurations are stored. These are items that get the cluster/automation started. They are usually install manifests of the GitOps controller.<br /><br />`base` is where are the "common" YAML would live and `overlays` are configurations specific to the cluster.<br /><br />The `kustomization.yaml` file in `default` has all the directories under `cluster-XXXX/components/` as a part of it's `bases` config.|
| 3. | `components` | This is where specific components for the GitOps Controller lives. The directories here depend on the GitOps controller you are using.<br /><br /> For example, if you're using Argo CD, `applicationsets` and `argocdproj` are possible directories (each in their repsective configurations). For Flux, this is where `gitrepositories` and `kustomizations` (with their repsective configurations) would be stored.|
| 4. | `core` | This is where YAML for the core functionality of the cluster live. These are things that are necissary for the cluster to run/be usable. Here is where the Kubernetes administrator will put things that is necissary for the functionality of the cluster (like cluster configs or cluster workloads).<br /><br />Under `gitops-controller` is where you are using the GitOps controller to manage itself. The `kustomization.yaml` file uses `cluster-XXXX/bootstrap/overlays/default` in it's `bases` configuration. This `core` directory gets deployed as a workload.<br /><br />To add a new "core functionality" workoad, one needs to add a directory with some yaml in the `core` directory. See the `sample-admin-config` directory as an example.|
| 5. | `tenants` | This is where the workloads for this cluster live.<br /><br />Similar to `core`, all directories under `tenants` gets deployed .<br /><br />This is where Devlopers/Release Engineers do the work. They just need to commit a directory with some YAML and the GitOps controller takes care of creating the workload.<br /><br /> **Note** that `bgd-blue/kustomization.yaml` file points to another Git repo. This is to show that you can host your YAML in one repo, or many repos, while still keeping one repo to manage the one cluster.|

# Noteworthy Things

Some of this layout may seem "overkill" for a single cluster, but there are reasons. 

* The `bootstrap` seems redundant as you are just referencing it in the `gitops-controller` directory. This is to "instill good habits" as the `bootstrap` directory comes in handly later when you're doing mono-repo (1 repo to many clusters).
* It may seem redundant to have `core` and `tenants`. You can fold this into one directory called `apps` because, functionally, `core` and `tenants` are the same thing. However, this is done (separating the two) as a way to set a demarcation between what "is needed in the cluster" and "what is using the cluster".
* There is an `overlays/default` directory for the same reason as there is `bootstrap` directory. Instilling good habits. This is, technically, unecissary for the functionality; but it's an important practice for other designs/implementations.

# Examples

I've added examples for Argo CD, Flux, and OpenShift GitOps. These examples won't work until they are merged. They are based on examples I have in my repo. So if you want to "fork and hack", I'd suggest you look at these

[Argo CD](https://github.com/christianh814/example-kubernetes-go-repo)
[Flux](https://github.com/christianh814/example-kubernetes-goflux-repo)
[OpenShift](https://github.com/christianh814/example-openshift-go-repo)