### PR TITLE
Add glossary item for "pull"

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -18,6 +18,10 @@ This glossary accompanies the [GitOps Principles](./PRINCIPLES.md), and other su
 - ## Drift
 
     When a system's actual state has moved or is in the process of moving away from the [desired state](#desired-state), this is often referred to as drift.
+    
+- ## Pull
+
+    In contrast to traditional, CI/CD pipelines which "push" event based triggers to discover state changes, in GitOps desired state is "pulled". This state may be reconciled with local or remote actual states. In GitOps agents are expected to pull both desired and actual states without the requirement of events. Webhooks may be used to speed up this process, but should a webhook fail, the agent is still expected to discover changes to desired state by pulling from the source of truth. 
 
 - ## Reconciliation
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -21,7 +21,10 @@ This glossary accompanies the [GitOps Principles](./PRINCIPLES.md), and other su
     
 - ## Pull
 
-    In contrast to traditional, CI/CD pipelines which "push" event based triggers to discover state changes, in GitOps desired state is "pulled". This state may be reconciled with local or remote actual states. In GitOps agents are expected to pull both desired and actual states without the requirement of events. Webhooks may be used to speed up this process, but should a webhook fail, the agent is still expected to discover changes to desired state by pulling from the source of truth. 
+    [Principle 3](./PRINCIPLES.md) specifies the desired state must be "pulled" rather than "pushed", primarily because the software agents must be able to access the [desired state](#desired-state) from the [state store](#state-store) at _any_ time, not only when there is an intentional change in the state store triggering a push event.
+    This is a prerequisite for [reconciliation](#reconciliation) to happen [continuously](#continuous), as specified in [principle 4](./PRINCIPLES.md).
+    Note that – in contrast to traditional CI/CD, where automation is generally driven by pre-set triggers – in GitOps, [reconciliation](#reconciliation) is triggered _whenever_ there is a divergence.
+    Divergence could be due to the actual state unintentionally [drifting](#drift) from the desired state declarations – not only due to a new desired state declaration version having been changed intentionally.
 
 - ## Reconciliation
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -15,7 +15,7 @@ The [desired state](./GLOSSARY.md#desired-state) of a GitOps managed system must
 
 3. **Pulled Automatically**
 
-    Software agents automatically pull the desired state declarations from the source.
+    Software agents automatically [pull]((./GLOSSARY.md#pull)) the desired state declarations from the source.
 
 4. **Continuously Reconciled**
 


### PR DESCRIPTION
From this discussion: https://github.com/open-gitops/project/discussions/134

> In light of ongoing discussions and questions in slack, of which this is the [most recent example](https://cloud-native.slack.com/archives/C01G9DEE88M/p1671020692512439), it seems prudent to explain what pull means.
> 
> Sometimes, readers understand "pull" to mean that GitOps agents must live in the infrastructure under management so that it is self-sufficient and does not require external agents. This however, is not the intention of the word pull. The word pull here is specifically in reference to how desired state is discovered.
> 

Signed-off-by: Dan Garfield <dan@codefresh.io>

Signed-off-by: Dan Garfield <dan@todaywasawesome.com>