### PR TITLE
Revert accidental change to unordered list

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -20,4 +20,3 @@ The [desired state](./GLOSSARY.md#desired-state) of a GitOps managed system must
 4. #### Continuously Reconciled
 
     Software agents [continuously](./GLOSSARY.md#continuous) observe actual system state and [attempt to apply](./GLOSSARY.md#reconciliation) the desired state.
-    

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -5,19 +5,19 @@ These principles are derived from modern software operations, but are also roote
 
 The [desired state](./GLOSSARY.md#desired-state) of a GitOps managed system must be:
 
-- ## Declarative
+1. #### Declarative
 
     A [system](./GLOSSARY.md#software-system) managed by GitOps must have its desired state expressed [declaratively](./GLOSSARY.md#declarative-description).
 
-- ## Versioned and Immutable
+2. #### Versioned and Immutable
 
     Desired state is [stored](./GLOSSARY.md#state-store) in a way that enforces immutability, versioning and retains a complete version history.
 
-- ## Pulled Automatically
+3. #### Pulled Automatically
 
     Software agents automatically [pull]((./GLOSSARY.md#pull)) the desired state declarations from the source.
 
-- ## Continuously Reconciled
+4. #### Continuously Reconciled
 
     Software agents [continuously](./GLOSSARY.md#continuous) observe actual system state and [attempt to apply](./GLOSSARY.md#reconciliation) the desired state.
     


### PR DESCRIPTION
fixes #68 

Preview: https://github.com/scottrigby/ogo-documents/blob/revert-to-ol/PRINCIPLES.md

Commit messages repeated here for clarity:

> 1. Revert to ordered list while keeping simple anchors
>
>    Use md h4 to use GitHub's auto-anchoring without a drastic visual difference
between the ol number and header. Alternatively we could add inline HTML
named anchors, but then the raw markdown is less human-readable.
>
> 1. Fix trailing spaces and multiple consecutive blank lines