### PR TITLE
Script to generate authors files by version for Bibtex

### DIFF
--- a/reference/authors-v1.0.0.md
+++ b/reference/authors-v1.0.0.md
@@ -1,0 +1,48 @@
+# v1.0.0 Authors
+
+This file is generated from Git history of the other canonical files in this repo,
+and is purely a convenience for referencing in academic papers.
+See the full Git history of those files for additional context.
+
+## Authors List
+
+- Andrew Block <ablock@redhat.com>
+- Brian Fox <brian@midnite-it.se>
+- Brian Fox <brianhfox@gmail.com>
+- Brice Fernandes <brice@weave.works>
+- Cansu Kavılı Örnek <ckavili@redhat.com>
+- Carlos Santana <csantana23@gmail.com>
+- Carlos Santana <csantana@us.ibm.com>
+- Chris Sanders <csand@microsoft.com>
+- Chris Short <chris@chrisshort.net>
+- Christian Hernandez <christian@redhat.com>
+- Cornelia Davis <ornelia@corneliadavis.com>
+- Dan Garfield <dan@todaywasawesome.com>
+- Daniel Warner <daniel.warner@codefresh.io>
+- Florian Heubeck <Heubeck@mediamarktsaturn.com>
+- Ishita Sequeira <isequeir@redhat.com>
+- Jesse Butler <butlerjl@amazon.com>
+- John Pitman <jpitman@redhat.com>
+- Kevin Bowersox <kmb385@gmail.com>
+- Kingdon Barrett <kingdon+github@tuesdaystudios.com>
+- Leonardo Murillo <leonardo@devops.cr>
+- Leonardo Murillo <leonardo@weave.works>
+- Lloyd Chang <lloydchang@gmail.com>
+- Lothar Schulz <mail@lotharschulz.info>
+- Michael Bridgen <mikeb@squaremobius.net>
+- Moshe Immerman <moshe@flanksource.com>
+- Nicholas Thomson <RedbackThomson@users.noreply.github.com>
+- Nicholas Thomson <nithomso@amazon.com>
+- Piotr <decoder@live.de>
+- Regina Scott <rescott@redhat.com>
+- Robert A Ficcaglia <rficcaglia@users.noreply.github.com>
+- Roberth Strand <me@robstr.dev>
+- Schlomo Schapiro <schlomo@schapiro.org>
+- Scott Rigby <scott@r6by.com>
+- Sean Sundberg <seansund@us.ibm.com>
+- Shoubhik Bose <shbose@redhat.com>
+- Timothy Lin <timothylin@deloitte.com>
+- Toni Menzel <toni.menzel@rebaze.com>
+- William Caban <william.caban@gmail.com>
+- William Chia <thewilliamchia@gmail.com>
+- lloydchang <lloydchang@gmail.com>

--- a/scripts/authors-by-version.sh
+++ b/scripts/authors-by-version.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Example usage:
+# mkdir -p reference
+# for VERSION in v1.0.0 HEAD; do
+#   ./scripts/authors-by-version.sh $VERSION > reference/authors-$VERSION.md
+# done
+
 # Authors, comitters, co-authors
 get_authors() {
     local git_tag="$1"

--- a/scripts/authors-by-version.sh
+++ b/scripts/authors-by-version.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Authors, comitters, co-authors
+get_authors() {
+    local git_tag="$1"
+    shift  # Shift arguments to get the files
+    local files="$@"
+    git --no-pager log "$git_tag" -- $files | \
+        sed -n -e 's/^Author: //p' -e 's/^Committer: //p' -e 's/^.*Co-authored-by: //p' | \
+        sort | uniq | sed -e 's/^/- /'
+}
+
+# Ensure tag argument is provided
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <git-tag>"
+    exit 1
+fi
+
+GIT_TAG="$1"
+
+if [ ! $(git tag -l "$GIT_TAG") ] && [ ! "$GIT_TAG" == "HEAD" ]; then
+    echo "<git-tag> '$GIT_TAG' does not exist"
+    exit 1
+fi
+
+# Check if translations
+git show "$GIT_TAG":i18n > /dev/null 2>&1 && i18n=true || i18n=false
+
+
+# Output
+cat <<EOF
+# $GIT_TAG Authors
+
+This file is generated from Git history of the other canonical files in this repo,
+and is purely a convenience for referencing in academic papers.
+See the full Git history of those files for additional context.
+
+EOF
+
+# If translations exist, output a note about language and translations
+if [ $i18n = true ]; then
+    cat <<EOF
+## Language and Translations
+
+The GitOps Principles and Glossary are [authored](#authors-list) in English.
+See farther below for a list of [translators](#translators-list) by language.
+
+EOF
+fi
+
+# Get authors list
+AUTHORS=$(get_authors "$GIT_TAG" "PRINCIPLES.md GLOSSARY.md")
+
+# Append to output
+cat <<EOF
+## Authors List
+
+$AUTHORS
+EOF
+
+# If translations exist, append translator lists
+if [ $i18n = true ]; then
+    # Get translator lists
+    DE=$(get_authors "$GIT_TAG" i18n/*_de.md)
+    ES=$(get_authors "$GIT_TAG" i18n/*_es.md)
+    PT=$(get_authors "$GIT_TAG" i18n/*_pt.md)
+    FR=$(get_authors "$GIT_TAG" i18n/*_fr.md)
+
+    # Append to output
+    cat <<EOF
+
+## Translators List
+
+### German
+
+$DE
+
+### Spanish
+
+$ES
+
+### Portuguese
+
+$PT
+
+### French
+
+$FR
+EOF
+fi


### PR DESCRIPTION
Automation script for #78 

- For a given release, outputs the list of authors, committers, and co-authors from Git history
- Git is still the canonical source of truth for contributions. These files are needed only for academic reference (see #78)
- If translations exist in a release, notes that the Principles and Glossary are authored in English, and outputs the list of translators per language
- I included an output file for our only non-pre-release tag, v1.0.0 (I'm assume we only want to create Bibtex reference files for full releases)
- The script also allows "HEAD" as an argument to allow a preview of what the output will look like before each new release

## Follow-up

- [ ] If we like this we can add to a GitHub Action (note last month GitHub added [release types](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release). We would want `released`)

## Example usage:

Note that until our next planned release, the only full release v1.0.0 does not yet have translations, so we're also outputting HEAD for comparison:

```bash
mkdir -p reference
for VERSION in v1.0.0 HEAD; do
  ./scripts/authors-by-version.sh $VERSION > reference/authors-$VERSION.md
done
```

## Example output:

Here's a git-like diff between the v1.0.0 and current HEAD files generated from the example command above:

<details>
 <summary>Click to expand diff</summary>

```diff
--- reference/authors-v1.0.0.md	2024-08-10 23:53:34
+++ reference/authors-HEAD.md	2024-08-10 23:53:35
@@ -1,9 +1,14 @@
-# v1.0.0 Authors
+# HEAD Authors
 
 This file is generated from Git history of the other canonical files in this repo,
 and is purely a convenience for referencing in academic papers.
 See the full Git history of those files for additional context.
 
+## Language and Translations
+
+The GitOps Principles and Glossary are [authored](#authors-list) in English.
+See farther below for a list of [translators](#translators-list) by language.
+
 ## Authors List
 
 - Andrew Block <ablock@redhat.com>
@@ -37,6 +42,7 @@
 - Regina Scott <rescott@redhat.com>
 - Robert A Ficcaglia <rficcaglia@users.noreply.github.com>
 - Roberth Strand <me@robstr.dev>
+- Samuel Tauil <samueltauil@gmail.com>
 - Schlomo Schapiro <schlomo@schapiro.org>
 - Scott Rigby <scott@r6by.com>
 - Sean Sundberg <seansund@us.ibm.com>
@@ -46,3 +52,29 @@
 - William Caban <william.caban@gmail.com>
 - William Chia <thewilliamchia@gmail.com>
 - lloydchang <lloydchang@gmail.com>
+
+## Translators List
+
+### German
+
+- Bernd Stübinger <bernd.stuebinger@gmx.de>
+- Florian Heubeck <40993644+heubeck@users.noreply.github.com>
+- Jan Knieling <knieling_jan@hotmail.com>
+- Jochen Bürkle <buerkle@mediamarktsaturn.com>
+- Kevin Fritz <fritzk@mediamarktsaturn.com>
+- Michael Rempel <mrempel23@gmail.com>
+- Richard Steinbrück <richard.steinbrueck@googlemail.com>
+- Tung Beier <beiertu@mediamarktsaturn.com>
+
+### Spanish
+
+- Diego Cristóbal Herreros <diecristher@gmail.com>
+
+### Portuguese
+
+- João Paulo Vanzuita <joaovanzuita@me.com>
+- Samuel Tauil <samueltauil@gmail.com>
+
+### French
+
+- Francois LP <francois@remazing.eu>
```
</details>